### PR TITLE
Improvement for large strings

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,9 @@
 // for large strings, use this from https://stackoverflow.com/a/49124600
-const buff_to_base64 = (buff) => btoa(new Uint8Array(buff).reduce(function (data, byte) {
-    return data + String.fromCharCode(byte);
-}, ''));
+const buff_to_base64 = (buff) => btoa(
+  new Uint8Array(buff).reduce(
+    (data, byte) => data + String.fromCharCode(byte), ''
+  )
+);
 
 const base64_to_buf = (b64) =>
   Uint8Array.from(atob(b64), (c) => c.charCodeAt(null));

--- a/script.js
+++ b/script.js
@@ -1,4 +1,7 @@
-const buff_to_base64 = (buff) => btoa(String.fromCharCode.apply(null, buff));
+// for large strings, use this from https://stackoverflow.com/a/49124600
+const buff_to_base64 = (buff) => btoa(new Uint8Array(buff).reduce(function (data, byte) {
+    return data + String.fromCharCode(byte);
+}, ''));
 
 const base64_to_buf = (b64) =>
   Uint8Array.from(atob(b64), (c) => c.charCodeAt(null));


### PR DESCRIPTION
This avoids the "RangeError: Maximum call stack size exceeded" on btoa for multi-kb strings